### PR TITLE
Fix login request

### DIFF
--- a/custom_components/saj_esolar/sensor.py
+++ b/custom_components/saj_esolar/sensor.py
@@ -407,7 +407,6 @@ class SAJeSolarMeterData(object):
                 'Accept-Language': 'nl-NL,nl;q=0.9,en-US;q=0.8,en;q=0.7',
                 'Cache-Control': 'max-age=0',
                 'Connection': 'keep-alive',
-                'Content-Length': '79',
                 'Content-Type': 'application/x-www-form-urlencoded',
                 'Cookie': 'org.springframework.web.servlet.i18n.CookieLocaleResolver.LOCALE=en; op_esolar_lang=en',
                 'DNT': '1',


### PR DESCRIPTION
Remove header 'Content-Length' containing (invalid) fixed length from login request.

This happens when len(payload) != 79 
Probably authors payload containing his/hers login+password has length of 79 :-)