### PR TITLE
fix for #81 pick total load power from column 1 of getPlantMeterChart…

### DIFF
--- a/custom_components/saj_esolar/sensor.py
+++ b/custom_components/saj_esolar/sensor.py
@@ -1207,7 +1207,7 @@ class SAJeSolarMeterSensor(SensorEntity):
                 if self._type == 'totalLoadPower':
                     if 'dataCountList' in energy:
                         if energy["getPlantMeterChartData"]['dataCountList'][4][-1] is not None:
-                            self._state = float(energy["getPlantMeterChartData"]['dataCountList'][2][-1])
+                            self._state = float(energy["getPlantMeterChartData"]['dataCountList'][1][-1])
                 if self._type == 'totalPvgenPower':
                     if 'dataCountList' in energy:
                         if energy["getPlantMeterChartData"]['dataCountList'][4][-1] is not None:


### PR DESCRIPTION
For users of the sec module, use the column 1 (load power) of getPlantMeterChartData instead of 2 (self-consumption) for `totalloadpower`

fixes #81 