### PR TITLE
add new entities for SEC module using the right columns from dataCountlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 SyncToy*
+.idea/

--- a/README.md
+++ b/README.md
@@ -178,13 +178,19 @@ If you have a Saj Sec Module Add below sensor an resources:
       - selfConsumedEnergy2
       - plantTreeNum
       - reduceCo2
-      - totalGridPower
-      - totalLoadPower
-      - totalPvgenPower
       - totalPvEnergy
       - totalLoadEnergy # Energy -> Grid consumption
       - totalBuyEnergy
       - totalSellEnergy # Energy -> Return to grid
+      #these entities are deprecated since they return incorrect values
+      - totalGridPower  # Power being exported to the grid
+      - totalLoadPower  # Solar power being currently self-consumed 
+      - totalPvgenPower # Power imported from the grid
+      #these new entities replace them
+      - gridLoadPower   # Power imported from the grid
+      - solarLoadPower  # Solar power being currently self-consumed 
+      - homeLoadPower   # Total power being consumed by the plant (the home)
+      - exportPower     # Power being exported to the grid
 ```
 <br><br>
 If you are a user of Solarprofit / Greenheiss

--- a/custom_components/saj_esolar/sensor.py
+++ b/custom_components/saj_esolar/sensor.py
@@ -109,9 +109,15 @@ SENSOR_LIST = {
     "selfConsumedEnergy2",
     "plantTreeNum",
     "reduceCo2",
+    #deprecated entities (values dont actually match what they meant to )
     "totalGridPower",
     "totalLoadPower",
     "totalPvgenPower",
+    #new saj entities
+    "gridLoadPower",
+    "solarLoadPower",
+    "homeLoadPower",
+    "exportPower",
     "totalPvEnergy",
     "totalLoadEnergy",
     "totalBuyEnergy",
@@ -376,6 +382,31 @@ SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         key="totalPvgenPower",
         name="totalPvgenPower",
         icon="mdi:solar-panel",
+        native_unit_of_measurement=UnitOfPower.WATT,
+    ),
+    SensorEntityDescription(
+        key="gridLoadPower",
+        name="gridLoadPower",
+        icon="mdi:transmission-tower-import",
+        native_unit_of_measurement=UnitOfPower.WATT,
+    ),
+    SensorEntityDescription(
+        key="solarLoadPower",
+        name="solarLoadPower",
+        icon="mdi:solar-power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.ENERGY,
+    ),
+    SensorEntityDescription(
+        key="homeLoadPower",
+        name="homeLoadPower",
+        icon="mdi:home-lightning-bolt-outline",
+        native_unit_of_measurement=UnitOfPower.WATT,
+    ),
+    SensorEntityDescription(
+        key="exportPower",
+        name="exportPower",
+        icon="mdi:transmission-tower-export",
         native_unit_of_measurement=UnitOfPower.WATT,
     ),
     SensorEntityDescription(
@@ -1199,20 +1230,37 @@ class SAJeSolarMeterSensor(SensorEntity):
                             self._state = (energy["getPlantMeterChartData"]['viewBean']["plantTreeNum"])
 
 
-                # dataCountList
+                # dataCountList, deprecated since use the wrong columns
                 if self._type == 'totalGridPower':
                     if 'dataCountList' in energy:
-                        if energy["getPlantMeterChartData"]['dataCountList'][4][-1] is not None:
+                        if energy["getPlantMeterChartData"]['dataCountList'][3][-1] is not None:
                             self._state = float(energy["getPlantMeterChartData"]['dataCountList'][3][-1])
                 if self._type == 'totalLoadPower':
                     if 'dataCountList' in energy:
-                        if energy["getPlantMeterChartData"]['dataCountList'][4][-1] is not None:
+                        if energy["getPlantMeterChartData"]['dataCountList'][2][-1] is not None:
                             self._state = float(energy["getPlantMeterChartData"]['dataCountList'][2][-1])
                 if self._type == 'totalPvgenPower':
                     if 'dataCountList' in energy:
                         if energy["getPlantMeterChartData"]['dataCountList'][4][-1] is not None:
                             self._state = float(energy["getPlantMeterChartData"]['dataCountList'][4][-1])
 
+                #dataCountList, new entities
+                if self._type == 'homeLoadPower':
+                    if 'dataCountList' in energy:
+                        if energy["getPlantMeterChartData"]['dataCountList'][1][-1] is not None:
+                            self._state = float(energy["getPlantMeterChartData"]['dataCountList'][1][-1])
+                if self._type == 'solarLoadPower':
+                    if 'dataCountList' in energy:
+                        if energy["getPlantMeterChartData"]['dataCountList'][2][-1] is not None:
+                            self._state = float(energy["getPlantMeterChartData"]['dataCountList'][2][-1])
+                if self._type == 'exportPower':
+                    if 'dataCountList' in energy:
+                        if energy["getPlantMeterChartData"]['dataCountList'][3][-1] is not None:
+                            self._state = float(energy["getPlantMeterChartData"]['dataCountList'][3][-1])
+                if self._type == 'gridLoadPower':
+                    if 'dataCountList' in energy:
+                        if energy["getPlantMeterChartData"]['dataCountList'][4][-1] is not None:
+                            self._state = float(energy["getPlantMeterChartData"]['dataCountList'][4][-1])
 
                 # getPlantMeterDetailInfo
                 if self._type == 'totalPvEnergy':


### PR DESCRIPTION
As discussed in the other PR, I kept the behaviour of the current SEC entities as they are and added a couple of new entities that match the data they provide.
I added deprecation notice to them to signal new users the new ones are the ones to choose from, but we dont need to remove the existing ones.

I was thinking if we should add an info or warn logging if users use the existing ones, I can add them if needed.

Here are some screenshots comparing the old and new entities vs a screenshot of my SAJ account. (nowPower has never come from that particular json even thought could also be obtained there)

<img width="895" alt="image" src="https://github.com/user-attachments/assets/bc7d9bc1-b1bd-4c6b-96d2-f2bdd60e8ee7">
