### PR TITLE
Modernize the code for newer Home Assistant versions, fix strict physics validation warnings, and improve error visibility

### DIFF
--- a/custom_components/saj_esolar/manifest.json
+++ b/custom_components/saj_esolar/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "saj_esolar",
   "name": "SAJ eSolar",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "requirements": [],
   "dependencies": [],
   "issue_tracker": "https://github.com/djansen1987/SAJeSolar/issues",

--- a/custom_components/saj_esolar/sensor.py
+++ b/custom_components/saj_esolar/sensor.py
@@ -13,7 +13,6 @@ import logging
 from typing import Final
 
 import aiohttp
-import async_timeout
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
@@ -34,7 +33,6 @@ from homeassistant.const import (
 )
 
 CONF_PLANT_ID: Final = "plant_id"
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle, dt
@@ -147,7 +145,7 @@ SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         name="nowPower",
         icon="mdi:solar-power",
         native_unit_of_measurement=UnitOfPower.WATT,
-        device_class=SensorDeviceClass.ENERGY,
+        device_class=SensorDeviceClass.POWER,
     ),
     SensorEntityDescription(
         key="runningState",
@@ -281,14 +279,14 @@ SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         name="peakPower",
         icon="mdi:solar-panel",
         native_unit_of_measurement=UnitOfPower.WATT,
-        device_class=SensorDeviceClass.ENERGY,
+        device_class=SensorDeviceClass.POWER,
     ),
     SensorEntityDescription(
         key="systemPower",
         name="systemPower",
         icon="mdi:solar-panel",
         native_unit_of_measurement=UnitOfPower.WATT,
-        device_class=SensorDeviceClass.ENERGY,
+        device_class=SensorDeviceClass.POWER,
     ),
     SensorEntityDescription(
         key="pvElec",
@@ -376,7 +374,7 @@ SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         name="totalLoadPower",
         icon="mdi:solar-panel",
         native_unit_of_measurement=UnitOfPower.WATT,
-        device_class=SensorDeviceClass.ENERGY,
+        device_class=SensorDeviceClass.POWER,
     ),
     SensorEntityDescription(
         key="totalPvgenPower",
@@ -395,7 +393,7 @@ SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         name="solarLoadPower",
         icon="mdi:solar-power",
         native_unit_of_measurement=UnitOfPower.WATT,
-        device_class=SensorDeviceClass.ENERGY,
+        device_class=SensorDeviceClass.POWER,
     ),
     SensorEntityDescription(
         key="homeLoadPower",
@@ -724,7 +722,7 @@ class SAJeSolarMeterData(object):
             previousChartYear = add_years(today, -1).strftime('%Y')
             nextChartYear = add_years(today, 1).strftime('%Y')
             chartYear = today.strftime('%Y')
-            epochmilliseconds = round(int((datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds() * 1000))
+            epochmilliseconds = int(dt.utcnow().timestamp() * 1000)
             elecDevicesn = deviceSnArr if self.sensors == "h1" else ""
             url4 = f"{self._provider.getBaseUrl()}/monitor/site/getPlantDetailChart2?plantuid={plantuid}&chartDateType=1&energyType=0&clientDate={clientDate}&deviceSnArr={deviceSnArr}&chartCountType=2&previousChartDay={previousChartDay}&nextChartDay={nextChartDay}&chartDay={chartDay}&previousChartMonth={previousChartMonth}&nextChartMonth={nextChartMonth}&chartMonth={chartMonth}&previousChartYear={previousChartYear}&nextChartYear={nextChartYear}&chartYear={chartYear}&elecDevicesn={elecDevicesn}&_={epochmilliseconds}"
             # _LOGGER.error(f"PlantCharts URL: {url4}")
@@ -866,11 +864,11 @@ class SAJeSolarMeterData(object):
                 self._data = plantDetails
 
         # Error logging
-        except aiohttp.ClientError:
-            _LOGGER.error("Cannot poll eSolar using url: %s")
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Cannot poll eSolar using url: %s", err)
             return
-        except asyncio.TimeoutError:
-            _LOGGER.error("Timeout error occurred while polling eSolar using url: %s")
+        except asyncio.TimeoutError as err:
+            _LOGGER.error("Timeout error occurred while polling eSolar using url: %s", err)
             return
         except Exception as err:
             _LOGGER.error("Unknown error occurred while polling eSolar: %s", err)
@@ -927,7 +925,7 @@ class SAJeSolarMeterSensor(SensorEntity):
         self._dev_id = {}
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor. (total/current power consumption/production or total gas used)"""
         return self._state
 


### PR DESCRIPTION
Home Assistant Architecture Updates:
1. Swapped state for native_value: Renamed the state property to native_value in the SAJeSolarMeterSensor class. Modern Home Assistant Core strictly requires this for sensors so it can handle unit conversions and state classes under the hood.
2. Modernized Timestamp Generation: Replaced the deprecated Python datetime.utcnow() math with Home Assistant's built-in dt.utcnow().timestamp() * 1000. This prevents the integration from crashing in Python 3.12+.

Device Class Corrections (Physics Fixes)
1. Changed ENERGY to POWER: Updated the device_class for several sensors (nowPower, peakPower, systemPower, totalLoadPower, and solarLoadPower). Home Assistant was likely throwing warnings because these sensors measure in Watts (Power), but were incorrectly labeled as measuring Energy (which expects kWh).

Better Error Logging
1. Exposed Hidden Errors: Fixed a bug in the try/except block where network errors were failing silently. The code now properly catches aiohttp.ClientError and asyncio.TimeoutError as the variable err and actively prints the actual error message to the Home Assistant logs.

Code Cleanup
1. Removed Unused Imports: Deleted the imports for async_timeout and async_get_clientsession at the top of the file since they were no longer being used by the integration. This keeps the code clean and prevents potential container load errors.