### PR TITLE
feat: Add multi-inverter support with strict backwards compatibility

### DIFF
--- a/custom_components/saj_esolar/manifest.json
+++ b/custom_components/saj_esolar/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "saj_esolar",
   "name": "SAJ eSolar",
-  "version": "1.5.7",
+  "version": "1.6.0",
   "requirements": [],
   "dependencies": [],
   "issue_tracker": "https://github.com/djansen1987/SAJeSolar/issues",

--- a/custom_components/saj_esolar/sensor.py
+++ b/custom_components/saj_esolar/sensor.py
@@ -66,7 +66,7 @@ DEVICE_TYPES = {
 
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(minutes=5)
 
-SENSOR_PREFIX = 'esolar '
+SENSOR_PREFIX = 'esolar'
 ATTR_MEASUREMENT = "measurement"
 ATTR_SECTION = "section"
 
@@ -544,6 +544,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional("provider_path", default="saj"):cv.string,
         vol.Optional("provider_protocol", default="https"):cv.string,
         vol.Optional("provider_ssl", default=True):cv.boolean,
+        vol.Optional("provider_id", default="test_id"):cv.string,
 
 
     }
@@ -561,7 +562,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     entities = []
     for description in SENSOR_TYPES:
         if description.key in config[CONF_RESOURCES]:
-            sensor = SAJeSolarMeterSensor(description, data, config.get(CONF_SENSORS), config.get(CONF_PLANT_ID))
+            sensor = SAJeSolarMeterSensor(description, data, config.get(CONF_SENSORS), config.get(CONF_PLANT_ID), config.get("provider_id"))
             entities.append(sensor)
     async_add_entities(entities, True)
     return True
@@ -907,7 +908,7 @@ class SAJeSolarMeterData(object):
 class SAJeSolarMeterSensor(SensorEntity):
     """Collecting data and return sensor entity."""
 
-    def __init__(self, description: SensorEntityDescription, data, sensors, plant_id):
+    def __init__(self, description: SensorEntityDescription, data, sensors, plant_id, provider_id):
         """Initialize the sensor."""
         self.entity_description = description
         self._data = data
@@ -917,11 +918,11 @@ class SAJeSolarMeterSensor(SensorEntity):
         self.plant_id = plant_id
         self._type = self.entity_description.key
         self._attr_icon = self.entity_description.icon
-        self._attr_name = f"{SENSOR_PREFIX}{self.entity_description.name}"
+        self._attr_name = f"{SENSOR_PREFIX} {provider_id} {self.entity_description.name}"
         self._attr_state_class = self.entity_description.state_class
         self._attr_native_unit_of_measurement = self.entity_description.native_unit_of_measurement
         self._attr_device_class = self.entity_description.device_class
-        self._attr_unique_id = f"{SENSOR_PREFIX}_{self._type}"
+        self._attr_unique_id = f"{SENSOR_PREFIX}_{provider_id}_{self._type}"
 
         self._discovery = False
         self._dev_id = {}

--- a/custom_components/saj_esolar/sensor.py
+++ b/custom_components/saj_esolar/sensor.py
@@ -544,7 +544,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional("provider_path", default="saj"):cv.string,
         vol.Optional("provider_protocol", default="https"):cv.string,
         vol.Optional("provider_ssl", default=True):cv.boolean,
-        vol.Optional("provider_id", default="test_id"):cv.string,
+        vol.Optional("provider_id", default=None):cv.string,
 
 
     }
@@ -908,7 +908,7 @@ class SAJeSolarMeterData(object):
 class SAJeSolarMeterSensor(SensorEntity):
     """Collecting data and return sensor entity."""
 
-    def __init__(self, description: SensorEntityDescription, data, sensors, plant_id, provider_id):
+    def __init__(self, description: SensorEntityDescription, data, sensors, plant_id, provider_id=None):
         """Initialize the sensor."""
         self.entity_description = description
         self._data = data
@@ -918,11 +918,19 @@ class SAJeSolarMeterSensor(SensorEntity):
         self.plant_id = plant_id
         self._type = self.entity_description.key
         self._attr_icon = self.entity_description.icon
-        self._attr_name = f"{SENSOR_PREFIX} {provider_id} {self.entity_description.name}"
         self._attr_state_class = self.entity_description.state_class
         self._attr_native_unit_of_measurement = self.entity_description.native_unit_of_measurement
         self._attr_device_class = self.entity_description.device_class
-        self._attr_unique_id = f"{SENSOR_PREFIX}_{provider_id}_{self._type}"
+
+        if provider_id:
+            # New behavior for users with multiple inverters
+            self._attr_name = f"{SENSOR_PREFIX} {provider_id} {self.entity_description.name}"
+            self._attr_unique_id = f"{SENSOR_PREFIX}_{provider_id}_{self._type}"
+        else:
+            # Old behavior: Preserves the exact strings of the original code, 
+            # including the old trailing space in the unique_id to prevent orphaned entities!
+            self._attr_name = f"{SENSOR_PREFIX} {self.entity_description.name}"
+            self._attr_unique_id = f"{SENSOR_PREFIX} _{self._type}"
 
         self._discovery = False
         self._dev_id = {}


### PR DESCRIPTION
This MR introduces the ability to configure multiple SAJ/Greenheiss inverters simultaneously within configuration.yaml, while safely preserving existing user configurations and historical data.

Key Changes:

- Multi-Inverter Support: Added a new optional provider_id to the PLATFORM_SCHEMA. When configured, this ID is injected into the sensor's name and unique_id (e.g., sensor.esolar_bir9_nowpower). This allows multiple integration blocks to run concurrently without entity ID collisions.
- Prefix Cleanup: Removed an accidental trailing space from the global SENSOR_PREFIX definition.
- Backwards Compatibility: To prevent orphaning existing users' sensors (which would wipe out their historical Energy Dashboard data), strict fallback logic was added to the SAJeSolarMeterSensor initialization. If provider_id is omitted (which defaults to None), the integration perfectly mirrors the legacy unique_id and naming structure, intentionally preserving the legacy spacing.

Testing:

- Verified that adding a provider_id correctly generates isolated sensors for multiple logins.
- Verified that omitting provider_id perfectly matches the legacy entity IDs, ensuring a seamless upgrade path for current users.